### PR TITLE
add data prep and eval for rel and cls

### DIFF
--- a/data/data_prep_utils.py
+++ b/data/data_prep_utils.py
@@ -1,9 +1,10 @@
 import torch
 from torch.nn.utils.rnn import pad_sequence
 import os
+import json
+
 
 def read_txt_file_ner(file_path):
-
     directories = file_path.split(os.path.sep)
     dataset_name = directories[-2]
 
@@ -17,7 +18,7 @@ def read_txt_file_ner(file_path):
                 sentences.append(sentence_tokens)
                 sentence_tokens = []
         else:
-            if dataset_name == 'sciie':
+            if dataset_name == "sciie":
                 token, pos_tag, _, ner_tag = line.strip().split(" ")
                 sentence_tokens.append((token, ner_tag))
             else:
@@ -25,11 +26,11 @@ def read_txt_file_ner(file_path):
                 sentence_tokens.append((token, ner_tag))
     if sentence_tokens:  # Append the last sentence if not empty
         sentences.append(sentence_tokens)
-        
+
     return sentences
 
-def read_txt_file_pico(file_path):
 
+def read_txt_file_pico(file_path):
     data = []  # List to store parsed data
     current_sentence = []
     with open(file_path, "r") as file:
@@ -50,6 +51,7 @@ def read_txt_file_pico(file_path):
 
     return data
 
+
 def tokenize_data_ner(sentences, tokenizer):
     tokenized_sentences = []
     for sentence in sentences:
@@ -62,8 +64,8 @@ def tokenize_data_ner(sentences, tokenizer):
         tokenized_sentences.append((tokens, labels))
     return tokenized_sentences
 
+
 def prepare_input_ner(tokenized_data, tokenizer, label_map, device):
-    
     token_ids = []
     attention_masks = []
     token_type_ids = []
@@ -72,12 +74,17 @@ def prepare_input_ner(tokenized_data, tokenizer, label_map, device):
     max_seq_length = max(len(tokens) for tokens, _ in tokenized_data)
 
     for tokens, entity_labels in tokenized_data:
-        encoded_dict = tokenizer.encode_plus(tokens, max_length=max_seq_length, pad_to_max_length=True, truncation=True, return_tensors='pt')
-        token_ids.append(encoded_dict['input_ids'])
-        attention_masks.append(encoded_dict['attention_mask'])
-        token_type_ids.append(encoded_dict['token_type_ids'])
+        encoded_dict = tokenizer.encode_plus(
+            tokens,
+            max_length=max_seq_length,
+            pad_to_max_length=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+        token_ids.append(encoded_dict["input_ids"])
+        attention_masks.append(encoded_dict["attention_mask"])
+        token_type_ids.append(encoded_dict["token_type_ids"])
         labels.append(torch.tensor([label_map[label] for label in entity_labels]))
-    
 
     token_ids = torch.cat(token_ids, dim=0)
     token_ids.to(device)
@@ -85,10 +92,11 @@ def prepare_input_ner(tokenized_data, tokenizer, label_map, device):
     attention_masks.to(device)
     token_type_ids = torch.cat(token_type_ids, dim=0)
     token_type_ids.to(device)
-    labels = pad_sequence(labels, batch_first=True, padding_value=label_map['O'])
+    labels = pad_sequence(labels, batch_first=True, padding_value=label_map["O"])
     labels.to(device)
 
     return token_ids, attention_masks, token_type_ids, labels
+
 
 def extract_labels(tokenized_sentences):
     all_labels = []
@@ -102,15 +110,15 @@ def extract_spans(labels, labels_mapper):
     spans = []
     current_span = None
     label_map_inv = {v: k for k, v in labels_mapper.items()}
-    
+
     for i, label_id in enumerate(labels):
         label = label_map_inv[label_id]
-        
+
         if label.startswith("B-"):
             if current_span is not None:
                 spans.append(current_span)
             current_span = {"type": label[2:], "start": i, "end": i}
-            
+
         elif label.startswith("I-"):
             if current_span is not None:
                 if current_span["type"] == label[2:]:
@@ -120,14 +128,62 @@ def extract_spans(labels, labels_mapper):
                     current_span = {"type": label[2:], "start": i, "end": i}
             else:
                 current_span = {"type": label[2:], "start": i, "end": i}
-                    
+
         else:  # Outside tag
             if current_span is not None:
                 spans.append(current_span)
                 current_span = None
-                
+
     if current_span is not None:
         spans.append(current_span)
-        
+
     return spans
 
+
+def collect_labels_rel_cls(file_paths):
+    labels = set()
+
+    for file_path in file_paths:
+        with open(file_path, "r", encoding="utf-8") as file:
+            for line in file:
+                try:
+                    data = json.loads(line.strip())
+                    labels.add(data["label"])
+                except json.JSONDecodeError as error:
+                    print(f"Error decoding JSON from line: {line}")
+                    print(error)
+    return labels
+
+
+def extract_texts_labels_rel_cls(file_path):
+    texts = []
+    labels = []
+
+    with open(file_path, "r", encoding="utf-8") as file:
+        for line in file:
+            try:
+                data = json.loads(line.strip())
+                texts.append(data["text"])
+                labels.append(data["label"])
+
+            except json.JSONDecodeError as error:
+                print(f"Error decoding JSON from line: {line}")
+                print(error)
+
+    return texts
+
+
+def tokenize_function(texts, tokenizer):
+    return tokenizer(
+        texts, truncation=True, max_length=512, return_tensors="pt", padding=True
+    )
+
+
+def prepare_input_rel_cls(tokenized_sentences, labels_mapper, labels, device):
+    labels_encoded = [labels_mapper[label] for label in labels]
+
+    token_ids = tokenized_sentences["input_ids"].to(device)
+    attention_masks = tokenized_sentences["attention_mask"].to(device)
+    token_type_ids = tokenized_sentences["token_type_ids"].to(device)
+
+    return labels_encoded, token_ids, attention_masks, token_type_ids

--- a/data/data_prep_utils.py
+++ b/data/data_prep_utils.py
@@ -172,7 +172,7 @@ def extract_texts_labels_rel_cls(file_path):
                 print(f"Error decoding JSON from line: {line}")
                 print(error)
 
-    return texts
+    return texts, labels
 
 
 def tokenize_function(texts, tokenizer):

--- a/data/data_prep_utils.py
+++ b/data/data_prep_utils.py
@@ -74,13 +74,15 @@ def prepare_input_ner(tokenized_data, tokenizer, label_map, device):
     max_seq_length = max(len(tokens) for tokens, _ in tokenized_data)
 
     for tokens, entity_labels in tokenized_data:
-        encoded_dict = tokenizer(
-            tokens,
-            max_length=max_seq_length,
-            pad_to_max_length=True,
-            truncation=True,
-            return_tensors="pt",
-        )
+        joined_text = " ".join(tokens)
+        encoded_dict = tokenizer.encode_plus(joined_text,
+                                             add_special_tokens=True,
+                                             max_length=max_seq_length, 
+                                             pad_to_max_length=True, 
+                                             truncation=True, 
+                                             return_attention_mask=True,
+                                             return_token_type_ids=True,
+                                             return_tensors='pt')
         token_ids.append(encoded_dict["input_ids"])
         attention_masks.append(encoded_dict["attention_mask"])
         token_type_ids.append(encoded_dict["token_type_ids"])

--- a/data/data_prep_utils.py
+++ b/data/data_prep_utils.py
@@ -182,10 +182,10 @@ def tokenize_function(texts, tokenizer):
 
 
 def prepare_input_rel_cls(tokenized_sentences, labels_mapper, labels, device):
-    labels_encoded = [labels_mapper[label] for label in labels]
 
     token_ids = tokenized_sentences["input_ids"].to(device)
     attention_masks = tokenized_sentences["attention_mask"].to(device)
     token_type_ids = tokenized_sentences["token_type_ids"].to(device)
+    labels_encoded = [labels_mapper[label] for label in labels]
 
-    return labels_encoded, token_ids, attention_masks, token_type_ids
+    return token_ids, attention_masks, token_type_ids, labels_encoded

--- a/data/data_prep_utils.py
+++ b/data/data_prep_utils.py
@@ -77,8 +77,8 @@ def prepare_input_ner(tokenized_data, tokenizer, label_map, device):
         joined_text = " ".join(tokens)
         encoded_dict = tokenizer.encode_plus(joined_text,
                                              add_special_tokens=True,
-                                             max_length=max_seq_length, 
-                                             pad_to_max_length=True, 
+                                             max_length=max_seq_length,
+                                             padding='max_length',
                                              truncation=True, 
                                              return_attention_mask=True,
                                              return_token_type_ids=True,

--- a/data/data_prep_utils.py
+++ b/data/data_prep_utils.py
@@ -142,7 +142,7 @@ def extract_spans(labels, labels_mapper):
     return spans
 
 
-def collect_labels_rel_cls(file_paths):
+def get_labels_rel_cls(file_paths):
     labels = set()
 
     for file_path in file_paths:

--- a/data/data_prep_utils.py
+++ b/data/data_prep_utils.py
@@ -74,7 +74,7 @@ def prepare_input_ner(tokenized_data, tokenizer, label_map, device):
     max_seq_length = max(len(tokens) for tokens, _ in tokenized_data)
 
     for tokens, entity_labels in tokenized_data:
-        encoded_dict = tokenizer.encode_plus(
+        encoded_dict = tokenizer(
             tokens,
             max_length=max_seq_length,
             pad_to_max_length=True,

--- a/data/prepare_data.py
+++ b/data/prepare_data.py
@@ -23,7 +23,6 @@ class DatasetPrep:
         data_path: str that describes the path where the train.txt, dev.txt, and test.txt datasets are
         tokenizer: Transformer's tokenizer according to the model used
         device: current device
-        label: list of labels used in the current task
         """
         self.task = task
         self.data_path = data_path
@@ -49,32 +48,32 @@ class DatasetPrep:
         dataset_dict = DatasetDict()
 
         for dataset in data_types:
+            # Read txt file based on given task
             if self.task == "ner":
                 sentences = read_txt_file_ner(self.data_path + "/" + dataset + ".txt")
                 tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
+
             elif self.task == "pico":
                 sentences = read_txt_file_pico(self.data_path + "/" + dataset + ".txt")
                 tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
+
             elif self.task == "rel" or self.task == "cls":
                 sentences, categor_labels = extract_texts_labels_rel_cls(
                     self.data_path + "/" + dataset + ".txt"
                 )
                 tokenized_sentences = tokenize_function(sentences, self.tokenizer)
 
+            # Get tokenized input based on task
             if self.task == "ner" or self.task == "pico":
                 token_ids, attention_masks, token_type_ids, labels = prepare_input_ner(
                     tokenized_sentences, self.tokenizer, labels_mapper, self.device
                 )
             elif self.task == "rel" or self.task == "cls":
-                (
-                    token_ids,
-                    attention_masks,
-                    token_type_ids,
-                    labels,
-                ) = prepare_input_rel_cls(
+                token_ids, attention_masks, token_type_ids, labels = prepare_input_rel_cls(
                     tokenized_sentences, labels_mapper, categor_labels, self.device
                 )
 
+            # Create a Dataset object
             dataset_inputs = Dataset.from_dict(
                 {
                     "input_ids": token_ids,

--- a/data/prepare_data.py
+++ b/data/prepare_data.py
@@ -1,72 +1,97 @@
 import torch
 from torch.utils.data import DataLoader
 from torch.nn.utils.rnn import pad_sequence
+import os
 from datasets import Dataset, DatasetDict
 from data.data_prep_utils import (
     read_txt_file_ner,
-    read_txt_file_pico, 
-    tokenize_data_ner, 
-    prepare_input_ner, 
-    extract_labels
+    read_txt_file_pico,
+    tokenize_data_ner,
+    prepare_input_ner,
+    extract_labels,
+    collect_labels_rel_cls,
+    extract_texts_labels_rel_cls,
+    tokenize_function,
+    prepare_input_rel_cls,
 )
 
 
 class DatasetPrep:
-
     def __init__(self, task, data_path, tokenizer, device) -> None:
         """
         task: should be 'ner', ....
         data_path: str that describes the path where the train.txt, dev.txt, and test.txt datasets are
         tokenizer: Transformer's tokenizer according to the model used
-        device: current device 
+        device: current device
         label: list of labels used in the current task
         """
         self.task = task
         self.data_path = data_path
         self.tokenizer = tokenizer
         self.device = device
-    
+
     def run(self) -> Dataset:
-        
-        if self.task == 'ner' or self.task == 'pico':
-            dataset_dict, labels_mapper = self.prep_ner_data()
-            return dataset_dict, labels_mapper
-        else:
-            return None
+        dataset_dict, labels_mapper = self.prep_data()
+        return dataset_dict, labels_mapper
 
-    def prep_ner_data(self):
+    def prep_data(self):
+        data_types = ["train", "dev", "test"]
 
-        data_types = ['train', 'dev', 'test']
-        labels_list = self._get_labels_list()
-        labels_mapper = {label: i for i, label in enumerate(set(labels_list))}
+        if self.task == "ner" or self.task == "pico":
+            labels_list = self._get_labels_list()
+            labels_mapper = {label: i for i, label in enumerate(set(labels_list))}
+        elif self.task == "rel" or self.task == "cls":
+            file_paths = [dataset + ".txt" for dataset in data_types]
+            file_paths = [os.path.join(self.data_path, path) for path in file_paths]
+            labels_set = collect_labels_rel_cls(file_paths)
+            labels_mapper = {label: i for i, label in enumerate(labels_set)}
+
         dataset_dict = DatasetDict()
 
         for dataset in data_types:
-            if self.task == 'ner':
+            if self.task == "ner":
                 sentences = read_txt_file_ner(self.data_path + "/" + dataset + ".txt")
-            elif self.task == 'pico':
+                tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
+            elif self.task == "pico":
                 sentences = read_txt_file_pico(self.data_path + "/" + dataset + ".txt")
+                tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
+            elif self.task == "rel" or self.task == "cls":
+                sentences, categor_labels = extract_texts_labels_rel_cls(
+                    self.data_path + "/" + dataset + ".txt"
+                )
+                tokenized_sentences = tokenize_function(sentences, self.tokenizer)
 
-            tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
-            token_ids, attention_masks, token_type_ids, labels = prepare_input_ner(tokenized_sentences, self.tokenizer,labels_mapper, self.device)
-            
-            dataset_inputs = Dataset.from_dict({
-                'input_ids': token_ids,
-                'attention_mask': attention_masks,
-                'token_type_ids': token_type_ids,
-                'labels': labels
-                })
+            if self.task == "ner" or self.task == "pico":
+                token_ids, attention_masks, token_type_ids, labels = prepare_input_ner(
+                    tokenized_sentences, self.tokenizer, labels_mapper, self.device
+                )
+            elif self.task == "rel" or self.task == "cls":
+                (
+                    token_ids,
+                    attention_masks,
+                    token_type_ids,
+                    labels,
+                ) = prepare_input_rel_cls(
+                    tokenized_sentences, labels_mapper, categor_labels, self.device
+                )
+
+            dataset_inputs = Dataset.from_dict(
+                {
+                    "input_ids": token_ids,
+                    "attention_mask": attention_masks,
+                    "token_type_ids": token_type_ids,
+                    "labels": labels,
+                }
+            )
 
             dataset_dict[dataset] = dataset_inputs
 
         return dataset_dict, labels_mapper
 
-
     def _get_labels_list(self):
-        
-        if self.task == 'ner':
+        if self.task == "ner":
             sentences = read_txt_file_ner(self.data_path + "/train.txt")
-        elif self.task =='pico':
+        elif self.task == "pico":
             sentences = read_txt_file_pico(self.data_path + "/train.txt")
 
         tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
@@ -74,4 +99,3 @@ class DatasetPrep:
         labels_list = list(set(all_labels))
 
         return labels_list
-        

--- a/data/prepare_data.py
+++ b/data/prepare_data.py
@@ -1,7 +1,6 @@
 import torch
 from torch.utils.data import DataLoader
 from torch.nn.utils.rnn import pad_sequence
-import os
 from datasets import Dataset, DatasetDict
 from data.data_prep_utils import (
     read_txt_file_ner,
@@ -9,12 +8,13 @@ from data.data_prep_utils import (
     tokenize_data_ner,
     prepare_input_ner,
     extract_labels,
-    collect_labels_rel_cls,
+    get_labels_rel_cls,
     extract_texts_labels_rel_cls,
     tokenize_function,
     prepare_input_rel_cls,
 )
-
+from typing import Dict
+import os
 
 class DatasetPrep:
     def __init__(self, task, data_path, tokenizer, device) -> None:
@@ -29,38 +29,37 @@ class DatasetPrep:
         self.tokenizer = tokenizer
         self.device = device
 
-    def run(self) -> Dataset:
-        dataset_dict, labels_mapper = self.prep_data()
-        return dataset_dict, labels_mapper
+    def run(self) -> (DatasetDict, Dict):
+        """
+        A function that returns a DatasetDict object that includes train, dev, and test data samples. 
+        Additionally the function returns a dictionary of all labels in the dataset mapped to categorical numbers. 
+        """
 
-    def prep_data(self):
         data_types = ["train", "dev", "test"]
 
-        if self.task == "ner" or self.task == "pico":
-            labels_set = self._get_labels_list()
-        elif self.task == "rel" or self.task == "cls":
-            file_paths = [dataset + ".txt" for dataset in data_types]
-            file_paths = [os.path.join(self.data_path, path) for path in file_paths]
-            labels_set = collect_labels_rel_cls(file_paths)
+        data_paths = [self.data_path + "/" + dataset + ".txt" for dataset in data_types]
         
+        if self.task == "ner" or self.task == "pico":
+            labels_set = self.get_labels_ner_pico(data_paths)
+        elif self.task == "rel" or self.task == "cls":
+            labels_set = get_labels_rel_cls(data_paths)
+
         labels_mapper = {label: i for i, label in enumerate(labels_set)}
 
         dataset_dict = DatasetDict()
 
-        for dataset in data_types:
+        for path in data_paths:
             # Read txt file based on given task
             if self.task == "ner":
-                sentences = read_txt_file_ner(self.data_path + "/" + dataset + ".txt")
+                sentences = read_txt_file_ner(path)
                 tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
 
             elif self.task == "pico":
-                sentences = read_txt_file_pico(self.data_path + "/" + dataset + ".txt")
+                sentences = read_txt_file_pico(path)
                 tokenized_sentences = tokenize_data_ner(sentences, self.tokenizer)
 
             elif self.task == "rel" or self.task == "cls":
-                sentences, categor_labels = extract_texts_labels_rel_cls(
-                    self.data_path + "/" + dataset + ".txt"
-                )
+                sentences, categor_labels = extract_texts_labels_rel_cls(path)
                 tokenized_sentences = tokenize_function(sentences, self.tokenizer)
 
             # Get tokenized input based on task
@@ -83,7 +82,10 @@ class DatasetPrep:
                 }
             )
 
-            dataset_dict[dataset] = dataset_inputs
+            directory = path.split(os.path.sep)
+            dataset_name = directory[-1]
+
+            dataset_dict[dataset_name[:-4]] = dataset_inputs
 
         return dataset_dict, labels_mapper
 

--- a/data/prepare_data.py
+++ b/data/prepare_data.py
@@ -37,13 +37,13 @@ class DatasetPrep:
         data_types = ["train", "dev", "test"]
 
         if self.task == "ner" or self.task == "pico":
-            labels_list = self._get_labels_list()
-            labels_mapper = {label: i for i, label in enumerate(set(labels_list))}
+            labels_set = self._get_labels_list()
         elif self.task == "rel" or self.task == "cls":
             file_paths = [dataset + ".txt" for dataset in data_types]
             file_paths = [os.path.join(self.data_path, path) for path in file_paths]
             labels_set = collect_labels_rel_cls(file_paths)
-            labels_mapper = {label: i for i, label in enumerate(labels_set)}
+        
+        labels_mapper = {label: i for i, label in enumerate(labels_set)}
 
         dataset_dict = DatasetDict()
 

--- a/model_eval.py
+++ b/model_eval.py
@@ -158,9 +158,8 @@ class ModelEval:
             macro_f1 = f1_score(true_labels, predictions, average="macro")
             return macro_f1
 
-        # REL and CLS are evaluated based on sentence-level macro-F1
-        elif self.task == "cls" or self.task == "rel":
-            return None
+        #elif self.task == "cls" or self.task == "rel":
+        #    return None
 
 
 def main():
@@ -203,7 +202,7 @@ def main():
 
     if task == "ner":
         print("Macro F1 score (span-level): ", eval_score)
-    elif task == "pico":
+    elif task == "pico" or task == "rel" or task == "cls":
         print("Macro F1 score (token-level): ", eval_score)
 
 

--- a/model_eval.py
+++ b/model_eval.py
@@ -1,13 +1,19 @@
-from transformers import BertTokenizer, BertForTokenClassification, Trainer, TrainingArguments
+from transformers import (
+    BertTokenizer,
+    BertForTokenClassification,
+    BertForSequenceClassification,
+    Trainer,
+    TrainingArguments,
+)
 from data.prepare_data import DatasetPrep
 from data.data_prep_utils import extract_spans
 from sklearn.metrics import f1_score, precision_score, recall_score
 from collections import defaultdict
 import argparse
-import torch 
+import torch
+
 
 class ModelEval:
-
     def __init__(self, task, model_name, tokenizer_name, data_path, device):
         self.task = task
         self.model_name = model_name
@@ -15,128 +21,166 @@ class ModelEval:
         self.data_path = data_path
         self.device = device
 
-
     def train_model(self):
-
         tokenizer = BertTokenizer.from_pretrained(self.tokenizer_name)
         dataset_prep = DatasetPrep(
-            task=self.task, 
-            data_path=self.data_path, 
-            tokenizer=tokenizer, 
-            device=self.device
-            )   
+            task=self.task,
+            data_path=self.data_path,
+            tokenizer=tokenizer,
+            device=self.device,
+        )
         dataset_dict, labels_mapper = dataset_prep.run()
-            
-        model = BertForTokenClassification.from_pretrained(self.model_name, num_labels=len(labels_mapper))
+
+        if self.task == "ner" or self.task == "pico":
+            model = BertForTokenClassification.from_pretrained(
+                self.model_name, num_labels=len(labels_mapper)
+            )
+        elif self.task == "rel" or self.task == "cls":
+            model = BertForSequenceClassification.from_pretrained(
+                self.model_name, num_labels=len(labels_mapper)
+            )
+
         model = model.to(self.device)
-            
-           
+
         training_args = TrainingArguments(
             output_dir="./results",
             num_train_epochs=3,
             per_device_train_batch_size=8,
             report_to="wandb",
             logging_steps=100,
-            save_steps=500, 
+            save_steps=500,
             evaluation_strategy="steps",
             eval_steps=500,
-            )
+        )
 
         trainer = Trainer(
             model=model,
             args=training_args,
-            train_dataset=dataset_dict['train'], 
-            eval_dataset=dataset_dict['dev']
-            )
+            train_dataset=dataset_dict["train"],
+            eval_dataset=dataset_dict["dev"],
+        )
 
         trainer.train()
 
         trainer.save_model("results/models")
 
         return model, dataset_dict, labels_mapper
-            
-    
-    def evaluate_model(self):
 
+    def evaluate_model(self):
         trained_model, dataset_dict, labels_mapper = self.train_model()
         trained_model.eval()
 
         # NER is evaluated according to span-level macro F1
-        if self.task == 'ner':
-
+        if self.task == "ner":
             true_spans_by_type = defaultdict(list)
             predicted_spans_by_type = defaultdict(list)
-            
-            for sample in dataset_dict['test']:
-                inputs = {key: torch.tensor(sample[key]).unsqueeze(0).to(self.device) for key in sample.keys() if key != 'labels'}
+
+            for sample in dataset_dict["test"]:
+                inputs = {
+                    key: torch.tensor(sample[key]).unsqueeze(0).to(self.device)
+                    for key in sample.keys()
+                    if key != "labels"
+                }
                 labels = sample["labels"]
-            
+
                 with torch.no_grad():
                     outputs = trained_model(**inputs)
-                    predictions = torch.argmax(outputs.logits, dim=-1).squeeze(0).tolist()
-                    
+                    predictions = (
+                        torch.argmax(outputs.logits, dim=-1).squeeze(0).tolist()
+                    )
+
                 true_spans = extract_spans(labels, labels_mapper)
                 predicted_spans = extract_spans(predictions, labels_mapper)
-    
+
                 for span in true_spans:
                     true_spans_by_type[span["type"]].append(span)
-            
+
                 for span in predicted_spans:
                     predicted_spans_by_type[span["type"]].append(span)
-                
-        
+
             # Compute F1 score for each span type
-            span_types = set(list(true_spans_by_type.keys()) + list(predicted_spans_by_type.keys()))
+            span_types = set(
+                list(true_spans_by_type.keys()) + list(predicted_spans_by_type.keys())
+            )
             macro_f1_scores = []
-    
+
             for span_type in span_types:
-                true_positives = sum(1 for span in predicted_spans_by_type[span_type] if span in true_spans_by_type[span_type])
-                false_positives = sum(1 for span in predicted_spans_by_type[span_type] if span not in true_spans_by_type[span_type])
-                false_negatives = sum(1 for span in true_spans_by_type[span_type] if span not in predicted_spans_by_type[span_type])
-            
+                true_positives = sum(
+                    1
+                    for span in predicted_spans_by_type[span_type]
+                    if span in true_spans_by_type[span_type]
+                )
+                false_positives = sum(
+                    1
+                    for span in predicted_spans_by_type[span_type]
+                    if span not in true_spans_by_type[span_type]
+                )
+                false_negatives = sum(
+                    1
+                    for span in true_spans_by_type[span_type]
+                    if span not in predicted_spans_by_type[span_type]
+                )
+
                 precision = true_positives / (true_positives + false_positives + 1e-9)
                 recall = true_positives / (true_positives + false_negatives + 1e-9)
                 f1 = 2 * (precision * recall) / (precision + recall + 1e-9)
-                
+
                 macro_f1_scores.append(f1)
-    
+
             macro_f1_score = sum(macro_f1_scores) / len(macro_f1_scores)
-            
+
             return macro_f1_score
 
         # PICO is evaluated based on token-level macro-F1
-        elif self.task == 'pico':
-
+        elif self.task == "pico" or self.task == "rel" or self.task == "cls":
             predictions = []
             true_labels = []
 
-            for sample in dataset_dict['test']:
-                
-                inputs = {key: torch.tensor(sample[key]).unsqueeze(0).to(self.device) for key in sample.keys() if key != 'labels'}
+            for sample in dataset_dict["test"]:
+                inputs = {
+                    key: torch.tensor(sample[key]).unsqueeze(0).to(self.device)
+                    for key in sample.keys()
+                    if key != "labels"
+                }
                 labels = sample["labels"]
-                
+
                 with torch.no_grad():
                     outputs = trained_model(**inputs)
-                    predicted_labels = torch.argmax(outputs.logits, dim=-1).squeeze(0).tolist()
+                    predicted_labels = (
+                        torch.argmax(outputs.logits, dim=-1).squeeze(0).tolist()
+                    )
 
                 # Extend lists
                 predictions.extend(predicted_labels)
                 true_labels.extend(labels)
 
             # Compute metrics
-            macro_f1 = f1_score(true_labels, predictions, average='macro')
+            macro_f1 = f1_score(true_labels, predictions, average="macro")
             return macro_f1
-        
+
         # REL and CLS are evaluated based on sentence-level macro-F1
-        elif self.task == 'cls' or self.task == 'rel':
+        elif self.task == "cls" or self.task == "rel":
             return None
+
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-t', '--task', type=str, help='Specify the task name')
-    parser.add_argument('-m', '--model', type=str, help='Specify the model name from huggingface')
-    parser.add_argument('-k', '--tokenizer', type=str, help='Specify the tokenizer name from huggingface')
-    parser.add_argument('-d', '--data', type=str, help='Specify the data path (the folder that contains train.txt, dev.txt, and test.txt)')
+    parser.add_argument("-t", "--task", type=str, help="Specify the task name")
+    parser.add_argument(
+        "-m", "--model", type=str, help="Specify the model name from huggingface"
+    )
+    parser.add_argument(
+        "-k",
+        "--tokenizer",
+        type=str,
+        help="Specify the tokenizer name from huggingface",
+    )
+    parser.add_argument(
+        "-d",
+        "--data",
+        type=str,
+        help="Specify the data path (the folder that contains train.txt, dev.txt, and test.txt)",
+    )
 
     args = parser.parse_args()
 
@@ -148,20 +192,20 @@ def main():
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
     model_eval = ModelEval(
-        task=task, 
+        task=task,
         model_name=model_name,
         tokenizer_name=tokenizer_name,
         data_path=data_path,
-        device=device
-        )
+        device=device,
+    )
 
     eval_score = model_eval.evaluate_model()
 
-    if task == 'ner':
+    if task == "ner":
         print("Macro F1 score (span-level): ", eval_score)
-    elif task == 'pico':
+    elif task == "pico":
         print("Macro F1 score (token-level): ", eval_score)
 
-    
+
 if __name__ == "__main__":
     main()

--- a/model_eval.py
+++ b/model_eval.py
@@ -149,9 +149,13 @@ class ModelEval:
                         torch.argmax(outputs.logits, dim=-1).squeeze(0).tolist()
                     )
 
-                # Extend lists
-                predictions.extend(predicted_labels)
-                true_labels.extend(labels)
+                if self.task == "pico":
+                    # Results for pico are lists but integers for the other tasks
+                    predictions.extend(predicted_labels)
+                    true_labels.extend(labels)
+                else:
+                    predictions.append(predicted_labels)
+                    true_labels.append(labels)
 
             directories = self.data_path.split(os.path.sep)
             dataset_name = directories[-1]

--- a/model_eval.py
+++ b/model_eval.py
@@ -11,6 +11,7 @@ from sklearn.metrics import f1_score, precision_score, recall_score
 from collections import defaultdict
 import argparse
 import torch
+import os
 
 
 class ModelEval:

--- a/model_eval.py
+++ b/model_eval.py
@@ -152,6 +152,14 @@ class ModelEval:
                 predictions.extend(predicted_labels)
                 true_labels.extend(labels)
 
+            directories = self.data_path.split(os.path.sep)
+            dataset_name = directories[-1]
+
+            # ChemProt is evaluated using Micro-F1
+            if dataset_name == 'chemprot':
+                micro_f1 = f1_score(true_labels, predictions, average="micro")
+                return micro_f1
+
             # Compute metrics
             macro_f1 = f1_score(true_labels, predictions, average="macro")
             return macro_f1

--- a/model_eval.py
+++ b/model_eval.py
@@ -171,26 +171,10 @@ class ModelEval:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-t", 
-        "--task", 
-        type=str, 
-        help="Specify the task name")
-    parser.add_argument(
-        "-m", "--model", type=str, help="Specify the model name from huggingface"
-    )
-    parser.add_argument(
-        "-k",
-        "--tokenizer",
-        type=str,
-        help="Specify the tokenizer name from huggingface",
-    )
-    parser.add_argument(
-        "-d",
-        "--data",
-        type=str,
-        help="Specify the data path (the folder that contains train.txt, dev.txt, and test.txt)",
-    )
+    parser.add_argument("-t", "--task", type=str, help="Specify the task name")
+    parser.add_argument("-m", "--model", type=str, help="Specify the model name from huggingface")
+    parser.add_argument("-k", "--tokenizer", type=str, help="Specify the tokenizer name from huggingface")
+    parser.add_argument("-d", "--data", type=str, help="Specify the data path (the folder that contains train.txt, dev.txt, and test.txt)")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
1. our label mappers are almost the same but in my case` collect_labels_rel_cls()` already returns a set of labels. It would be great if` _get_labels_list()` does the same. Then we can have a single mapper, i.e., `labels_mapper = {label: i for i, label in enumerate(labels_set)}`
2. it would be nice to find a common way to collect the labels for mapping. See how I collect them on lines 44-46 in prepapre_data.py. Maybe you can do the same or will have an idea how to do it more efficiently.
3. evaluation for rel and cls is the same as for pico. The only difference was the issue we faced with `.extend()`. I did not change it, just test it first. If there is the same error then we need to put `predictions.append(predicted_labels) true_labels.append(labels)` instead of `.extend()`
4. I guess we also need to change the print here since rel/cls are evaluated on the sentence level: 
```
elif task == "pico" or task == "rel" or task == "cls":
        print("Macro F1 score (token-level): ", eval_score)
```

